### PR TITLE
Replacing get_permalink with a more generic solution for finding out the current URL

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -117,7 +117,7 @@ class Admin {
             minlength="0"
             maxlength="80"
             value="<?php echo $bm_velobasar_formurl ?>" required />
-                 <p class="description"><?php echo sprintf( __('Fixe URL f&uuml;r Form Submit (0-80 Zeichen) [optional]. Default: Aktuelle Permalink-URL. Auf der Zielseite mu&szlig; der Shortcode installiert sein.', 'bm-velobasar')) ?></p>
+                 <p class="description"><?php echo sprintf( __('Fixe URL f&uuml;r Form Submit (0-80 Zeichen) [optional]. Default: Aktuell angezeigte Url. Auf der Zielseite mu&szlig; der Shortcode installiert sein.', 'bm-velobasar')) ?></p>
         <?php
     }
 

--- a/includes/class-shortcode.php
+++ b/includes/class-shortcode.php
@@ -38,7 +38,8 @@ class Shortcode {
         }
         $bm_velobasar_formurl = get_option('bm_velobasar_formurl');
         if( ! $bm_velobasar_formurl ) {
-            $bm_velobasar_formurl = get_permalink();
+            global $wp;
+            $bm_velobasar_formurl = add_query_arg( $wp->query_vars, home_url( $wp->request ) );
         }
 
         ob_start();


### PR DESCRIPTION
get_permalink seemed to be an incorrect solution for what we wanted, since it was not generic. I found a generic solution that would retrieve the current URL regardless of permalink settings, hopefully.